### PR TITLE
Improve rover polling

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,10 @@
         "**/.pytest_cache": true,
         "**/.mypy_cache": true,
         "**/venv": true
-    }
+    },
+    "black-formatter.args": [
+        "--line-length",
+        "120"
+    ],
+    "python.analysis.typeCheckingMode": "standard"
 }

--- a/install.sh
+++ b/install.sh
@@ -40,7 +40,7 @@ list_devices() {
     pid=$(echo "$info" | grep ^ID_MODEL_ID= | cut -d= -f2)
     model=$(echo "$info" | grep ^ID_MODEL= | cut -d= -f2)
     serial=$(echo "$info" | grep ^ID_SERIAL_SHORT= | cut -d= -f2)
-    echo "$tty - ${vid}:${pid} - $model ($serial)"
+    echo "$tty - ID_MODEL=\"${model}\" [ID_VENDOR_ID=${vid} ID_MODEL_ID=${pid} ID_SERIAL_SHORT=\"${serial})\"]"
   done
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,19 +4,15 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ve-renogy-rover"
-version = "0.1.0"
+version = "0.1.1"
 description = "D-Bus service to integrate Renogy Rover MPPT with Victron Venus OS"
 authors = [{ name = "Seb Martin" }]
 readme = "README.md"
 requires-python = ">=3.8"
-dependencies = [
-    "pyrover @ git+https://github.com/sebmartin/pyrover.git"
-]
+dependencies = ["pyrover @ git+https://github.com/sebmartin/pyrover.git"]
 
 [project.optional-dependencies]
-dev = [
-    "pytest"
-]
+dev = ["pytest"]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/service-template/run
+++ b/service-template/run
@@ -1,3 +1,3 @@
 #!/bin/sh
 exec 2>&1
-exec python -m ve_renogy_rover.rover_service TTY
+exec python3 -m ve_renogy_rover.rover_service TTY

--- a/src/ve_renogy_rover/rover_service.py
+++ b/src/ve_renogy_rover/rover_service.py
@@ -204,7 +204,7 @@ class RoverService(object):
 
         def solar_power():
             v = try_(rover.solar_voltage)
-            i = try_(rover.charging_current)
+            i = try_(rover.solar_current)
             if v is None or i is None:
                 return None
             return v * i
@@ -213,7 +213,7 @@ class RoverService(object):
             path: value
             for path, value in {
                 "/Pv/V": try_(rover.solar_voltage),
-                "/Pv/I": try_(rover.charging_current),
+                "/Pv/I": try_(rover.solar_current),
                 "/Yield/Power": solar_power(),
                 "/Dc/0/Voltage": try_(rover.battery_voltage),
                 "/Dc/0/Current": try_(rover.charging_current),

--- a/src/ve_renogy_rover/rover_service.py
+++ b/src/ve_renogy_rover/rover_service.py
@@ -6,12 +6,12 @@ https://github.com/sstoops/dbus-renogy-dcc/blob/main/dbus-renogy-dcc.py
 """
 
 import argparse
-from collections.abc import Callable
+from typing import Callable
 import logging
 import sys
 from enum import IntEnum
 from importlib.metadata import PackageNotFoundError, version
-from typing import Any
+from typing import Any, Optional
 
 from pyrover.renogy_rover import RenogyRoverController as Rover
 from pyrover.types import ChargingState
@@ -40,7 +40,7 @@ class OperationMode(IntEnum):
     TRACKING = 2
 
     @staticmethod
-    def from_rover(charging_state: ChargingState | None) -> "OperationMode | None":
+    def from_rover(charging_state: Optional[ChargingState]) -> Optional["OperationMode"]:
         if charging_state == ChargingState.DEACTIVATED:
             return OperationMode.OFF
         elif charging_state == ChargingState.CURRENT_LIMITING:
@@ -61,7 +61,7 @@ class State(IntEnum):
     EXTERNAL_CONTROL = 252
 
     @staticmethod
-    def from_rover(charging_state: ChargingState | None) -> "State | None":
+    def from_rover(charging_state: Optional[ChargingState]) -> Optional["State"]:
         if charging_state == ChargingState.DEACTIVATED:
             return State.OFF
         elif charging_state == ChargingState.BOOST:
@@ -225,10 +225,10 @@ class RoverService(object):
             if value is not None  # Don't update paths that raise an exception (if any)
         }
 
-        if (operation_mode := OperationMode.from_rover(rover.charging_state())) is not None:
+        if (operation_mode := OperationMode.from_rover(try_(rover.charging_state))) is not None:
             updates["/MppOperationMode"] = operation_mode.value
 
-        if (state := State.from_rover(rover.charging_state())) is not None:
+        if (state := State.from_rover(try_(rover.charging_state))) is not None:
             updates["/State"] = state.value
 
         with self._dbusservice as s:

--- a/src/ve_renogy_rover/rover_service.py
+++ b/src/ve_renogy_rover/rover_service.py
@@ -261,7 +261,10 @@ def main():
         logging.error("No device specified. Use --help for usage.")
         sys.exit(1)
 
-    logging.info(f"Starting driver on device: {args.device}")
+    device = args.device.strip()
+    device = device if device.startswith("/") else f"/dev/{device}"
+
+    logging.info(f"Starting driver on device: {device}")
 
     try:
         from dbus.mainloop.glib import DBusGMainLoop
@@ -269,7 +272,7 @@ def main():
         # Have a mainloop, so we can send/receive asynchronous calls to and from dbus
         DBusGMainLoop(set_as_default=True)
 
-        RoverService(tty=args.device)
+        RoverService(tty=device)
         logging.info("Service initialization complete.")
 
         mainloop = GLib.MainLoop()


### PR DESCRIPTION
Prevent the polling from terminating when pyrover raises an exception.

Also
 - enable linting in vscode
 - fix minor linting issues
 - add a few other dbus paths like `History/Daily/0/Yield` and `/History/Daily/0/MaxPower`