### PR TITLE
Improve exception handling and correct some dbus path values

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,9 @@
+[flake8]
+max-line-length = 120
+exclude =
+    .git,
+    __pycache__,
+    .venv,
+    venv,
+    .ruff_cache,
+    *.egg-info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v4
+        with:
+          # VenusOS uses Python 3.8 so let's just use that for now
+          python-version: "3.8"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run tests
+        run: |
+          pytest tests/ -v

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,5 +18,7 @@
         "--line-length",
         "120"
     ],
-    "python.analysis.typeCheckingMode": "standard"
+    "python.analysis.typeCheckingMode": "standard",
+    "editor.formatOnSave": true,
+    "black-formatter.importStrategy": "fromEnvironment"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
     "python.testing.pytestArgs": [
-        "tests"
+        "tests",
+        "-vv"
     ],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,
@@ -20,5 +21,11 @@
     ],
     "python.analysis.typeCheckingMode": "standard",
     "editor.formatOnSave": true,
-    "black-formatter.importStrategy": "fromEnvironment"
+    "black-formatter.importStrategy": "fromEnvironment",
+    "python.languageServer": "None",
+    "cursorpyright.analysis.extraPaths": [
+        "/usr/lib/python3.8/site-packages",
+        "/opt/victronenergy/dbus-systemcalc-py/ext/velib_python"
+    ],
+    "cursorpyright.analysis.typeCheckingMode": "standard"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,20 @@ requires-python = ">=3.8"
 dependencies = ["pyrover @ git+https://github.com/sebmartin/pyrover.git"]
 
 [project.optional-dependencies]
-dev = ["pytest"]
+dev = ["pytest", "pytest-cov", "pytest-mock"]
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]
+
+[tool.ruff]
+line-length = 120
+target-version = "py38"
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ve-renogy-rover"
-version = "0.1.1"
+version = "0.2.0"
 description = "D-Bus service to integrate Renogy Rover MPPT with Victron Venus OS"
 authors = [{ name = "Seb Martin" }]
 readme = "README.md"

--- a/src/ve_renogy_rover/dbus_service.py
+++ b/src/ve_renogy_rover/dbus_service.py
@@ -1,0 +1,73 @@
+from typing import Any, Protocol
+
+
+class DbusService(Protocol):
+    """
+    A protocol based on the VeDbusService class from the Victron Energy D-Bus library. This class
+    comes built-in with the Victron Energy system and is used to create D-Bus services. This Protocol
+    makes it easier to test and mock the DbusService in unit tests without needing the actual
+    Victron Energy library.
+    """
+
+    def register(self): ...
+
+    def __del__(self): ...
+
+    def get_name(self): ...
+
+    def add_path(
+        self,
+        path,
+        value,
+        description="",
+        writeable=False,
+        onchangecallback=None,
+        gettextcallback=None,
+        valuetype=None,
+        itemtype=None,
+    ): ...
+
+    def add_mandatory_paths(
+        self,
+        processname,
+        processversion,
+        connection,
+        deviceinstance,
+        productid,
+        productname,
+        firmwareversion,
+        hardwareversion,
+        connected,
+    ): ...
+
+    def __getitem__(self, path) -> Any: ...
+
+    def __setitem__(self, path, newvalue): ...
+
+    def __delitem__(self, path): ...
+
+    def __contains__(self, path) -> bool: ...
+
+    def __enter__(self) -> "ServiceContext": ...
+
+    def __exit__(self, *exc): ...
+
+
+class ServiceContext(object):
+    def __init__(self, parent): ...
+
+    def __contains__(self, path) -> bool: ...
+
+    def __getitem__(self, path) -> DbusService: ...
+
+    def __setitem__(self, path, newvalue): ...
+
+    def __delitem__(self, path): ...
+
+    def flush(self): ...
+
+    def add_path(self, path, value, *args, **kwargs): ...
+
+    def del_tree(self, root): ...
+
+    def get_name(self) -> str: ...

--- a/src/ve_renogy_rover/device_info.py
+++ b/src/ve_renogy_rover/device_info.py
@@ -1,12 +1,13 @@
+import json
 import logging
 import os
-import json
 from dataclasses import dataclass
 from random import randrange
 
 from pyrover.renogy_rover import RenogyRoverController as Rover
 
 PRODUCT_NAME = "Renogy Rover MPPT"
+
 
 @dataclass
 class DeviceInfo:
@@ -17,7 +18,7 @@ class DeviceInfo:
     hardware_version: str = "0.0.0"
 
     @staticmethod
-    def from_file(path: str) -> 'DeviceInfo':
+    def from_file(path: str) -> "DeviceInfo":
         """Load DeviceInfo from a JSON file."""
         try:
             with open(path, "r") as f:
@@ -26,13 +27,9 @@ class DeviceInfo:
             return DeviceInfo()
 
     @staticmethod
-    def from_dict(data: dict) -> 'DeviceInfo':
+    def from_dict(data: dict) -> "DeviceInfo":
         """Create DeviceInfo from a dictionary."""
-        args = {
-            key: value
-            for key, value in data.items()
-            if key in DeviceInfo.__dataclass_fields__
-        }
+        args = {key: value for key, value in data.items() if key in DeviceInfo.__dataclass_fields__}
         args.setdefault("serial", f"RNG-CTRL-RVR_{randrange(1000, 9999)}")
         return DeviceInfo(**args)
 

--- a/src/ve_renogy_rover/glib_wrapper.py
+++ b/src/ve_renogy_rover/glib_wrapper.py
@@ -1,0 +1,30 @@
+"""
+GLib wrapper for abstraction and easier testing.
+"""
+
+import logging
+from typing import Any, Callable
+
+
+def timeout_add(interval: int, callback: Callable[[], Any]) -> int:
+    """
+    Add a timeout callback using GLib.
+
+    Args:
+        interval: Timeout interval in milliseconds
+        callback: Function to call when timeout expires
+
+    Returns:
+        Timer ID or 0 if GLib not available
+    """
+    try:
+        import sys
+
+        # Add the paths to some system packages
+        sys.path.insert(1, "/usr/lib/python3.8/site-packages")
+        from gi.repository import GLib  # type: ignore
+
+        return GLib.timeout_add(interval, callback)
+    except ImportError:
+        logging.error("GLib not available - timeout_add ignored")
+        return 0

--- a/src/ve_renogy_rover/rover_service.py
+++ b/src/ve_renogy_rover/rover_service.py
@@ -215,6 +215,13 @@ class RoverService(object):
                 return None
             return v * i
 
+        def charging_current():
+            p = try_(rover.charging_power)
+            v = try_(rover.battery_voltage)
+            if p and v and v > 0:
+                return p / v
+            return 0.0
+
         try:
             updates = {
                 path: value
@@ -223,7 +230,7 @@ class RoverService(object):
                     "/Pv/I": try_(rover.charging_current),
                     "/Yield/Power": solar_power(),
                     "/Dc/0/Voltage": try_(rover.battery_voltage),
-                    "/Dc/0/Current": try_(rover.charging_current),
+                    "/Dc/0/Current": charging_current(),
                     "/Link/TemperatureSense": try_(rover.battery_temperature),
                     "/Link/TemperatureSenseActive": True,
                     "/History/Daily/0/Yield": try_(rover.power_generation_today) or 0.0,

--- a/src/ve_renogy_rover/rover_service.py
+++ b/src/ve_renogy_rover/rover_service.py
@@ -210,7 +210,7 @@ class RoverService(object):
 
         def solar_power():
             v = try_(rover.solar_voltage)
-            i = try_(rover.solar_current)
+            i = try_(rover.charging_current)
             if v is None or i is None:
                 return None
             return v * i
@@ -220,7 +220,7 @@ class RoverService(object):
                 path: value
                 for path, value in {
                     "/Pv/V": try_(rover.solar_voltage),
-                    "/Pv/I": try_(rover.solar_current),
+                    "/Pv/I": try_(rover.charging_current),
                     "/Yield/Power": solar_power(),
                     "/Dc/0/Voltage": try_(rover.battery_voltage),
                     "/Dc/0/Current": try_(rover.charging_current),

--- a/src/ve_renogy_rover/ve_dbus_service.py
+++ b/src/ve_renogy_rover/ve_dbus_service.py
@@ -1,0 +1,10 @@
+import sys
+
+from ve_renogy_rover.dbus_service import DbusService
+
+
+def create_ve_dbus_service(servicename) -> DbusService:
+    sys.path.insert(1, "/opt/victronenergy/dbus-systemcalc-py/ext/velib_python")
+    from vedbus import VeDbusService  # type: ignore
+
+    return VeDbusService(servicename, register=False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,146 @@
+import os
+import tempfile
+from typing import Any, Dict
+from unittest.mock import Mock
+
+import pytest
+
+# Add the src directory to the path so we can import the modules
+# sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+from pyrover.renogy_rover import RenogyRoverController
+from pyrover.types import ChargingState
+
+from ve_renogy_rover.dbus_service import DbusService, ServiceContext
+
+
+@pytest.fixture
+def mock_dbus_context():
+    """Fixture providing a mock DBus context for the context manager."""
+    context = Mock(spec=ServiceContext)
+    context.__getitem__ = Mock(return_value=0)
+    context.__setitem__ = Mock()
+    return context
+
+
+@pytest.fixture
+def mock_dbus_service(mock_dbus_context):
+    """Create a mock D-Bus service for testing."""
+    service = Mock(spec=DbusService)
+    service.__enter__ = Mock(return_value=mock_dbus_context)
+    service.__exit__ = Mock(return_value=None)
+    service.add_path = Mock()
+    service.register = Mock()
+    return service
+
+
+@pytest.fixture
+def mock_rover():
+    """Create a mock Renogy Rover controller for testing."""
+    rover = Mock(spec=RenogyRoverController)
+
+    # Mock all the rover methods that return values
+    rover.solar_voltage = Mock(return_value=24.5, __name__="solar_voltage")
+    rover.charging_current = Mock(return_value=2.1, __name__="charging_current")
+    rover.charging_power = Mock(return_value=50.0, __name__="charging_power")
+    rover.battery_voltage = Mock(return_value=12.8, __name__="battery_voltage")
+    rover.battery_temperature = Mock(return_value=25.0, __name__="battery_temperature")
+    rover.power_generation_today = Mock(return_value=1.2, __name__="power_generation_today")
+    rover.max_charging_power_today = Mock(return_value=50000, __name__="max_charging_power_today")  # 50W in mW
+    rover.charging_state = Mock(return_value=ChargingState.MPPT, __name__="charging_state")
+    rover.product_model = Mock(return_value="RNG-CTRL-RVR", __name__="product_model")
+    rover.serial_number = Mock(return_value="12345", __name__="serial_number")
+    rover.software_version = Mock(return_value="1.0.0", __name__="software_version")
+    rover.hardware_version = Mock(return_value="1.0.0", __name__="hardware_version")
+
+    return rover
+
+
+@pytest.fixture
+def mock_device_info():
+    """Create a mock DeviceInfo for testing."""
+    from ve_renogy_rover.device_info import DeviceInfo
+
+    device_info = Mock(spec=DeviceInfo)
+    device_info.product_name = "Renogy Rover MPPT"
+    device_info.custom_name = "Test Rover"
+    device_info.serial = "RNG-CTRL-RVR_1234"
+    device_info.firmware_version = "1.0.0"
+    device_info.hardware_version = "1.0.0"
+    return device_info
+
+
+@pytest.fixture
+def mock_device_info_class(mock_device_info):
+    """Fixture providing a mock DeviceInfo class with from_file method."""
+    from unittest.mock import patch
+
+    with patch("ve_renogy_rover.rover_service.DeviceInfo") as mock_class:
+        mock_class.from_file.return_value = mock_device_info
+        yield mock_class
+
+
+@pytest.fixture
+def mock_rover_class(mock_rover):
+    """Fixture providing a mock Rover class."""
+    from unittest.mock import patch
+
+    with patch("ve_renogy_rover.rover_service.Rover") as mock_class:
+        mock_class.return_value = mock_rover
+        yield mock_class
+
+
+@pytest.fixture
+def mock_timeout_add():
+    """Fixture providing a mock timeout add function."""
+    return Mock(return_value=123)
+
+
+@pytest.fixture
+def temp_settings_file():
+    """Create a temporary settings file for testing."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        f.write('{"custom_name": "Test Rover", "serial": "RNG-CTRL-RVR_1234"}')
+        temp_file = f.name
+
+    yield temp_file
+
+    # Cleanup
+    try:
+        os.unlink(temp_file)
+    except OSError:
+        pass
+
+
+@pytest.fixture
+def mock_glib():
+    """Mock GLib for testing."""
+    glib_mock = Mock()
+    glib_mock.timeout_add = Mock(return_value=123)  # Return a timer ID
+    return glib_mock
+
+
+@pytest.fixture
+def mock_mainloop():
+    """Mock GLib.MainLoop for testing."""
+    mainloop_mock = Mock()
+    mainloop_mock.run = Mock()
+    return mainloop_mock
+
+
+@pytest.fixture
+def sample_rover_data() -> Dict[str, Any]:
+    """Sample data that a real rover would return."""
+    return {
+        "solar_voltage": 24.5,
+        "charging_current": 2.1,
+        "charging_power": 50.0,
+        "battery_voltage": 12.8,
+        "battery_temperature": 25.0,
+        "power_generation_today": 1.2,
+        "max_charging_power_today": 50000,  # 50W in mW
+        "charging_state": None,
+        "product_model": "RNG-CTRL-RVR",
+        "serial_number": "12345",
+        "software_version": "1.0.0",
+        "hardware_version": "1.0.0",
+    }

--- a/tests/test_device_info.py
+++ b/tests/test_device_info.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+
+"""
+Tests for the device_info module.
+"""
+
+import json
+import os
+import tempfile
+from unittest.mock import Mock, patch
+
+from ve_renogy_rover.device_info import PRODUCT_NAME, DeviceInfo
+
+
+def test_default_values():
+    device_info = DeviceInfo()
+
+    assert device_info.product_name == PRODUCT_NAME
+    assert device_info.custom_name == PRODUCT_NAME
+    assert device_info.serial == "RNG-CTRL-RVR"
+    assert device_info.firmware_version == "0.0.0"
+    assert device_info.hardware_version == "0.0.0"
+
+
+def test_custom_values():
+    device_info = DeviceInfo(
+        product_name="Custom Product",
+        custom_name="My Rover",
+        serial="RNG-CTRL-RVR_1234",
+        firmware_version="1.2.3",
+        hardware_version="2.0.0",
+    )
+
+    assert device_info.product_name == "Custom Product"
+    assert device_info.custom_name == "My Rover"
+    assert device_info.serial == "RNG-CTRL-RVR_1234"
+    assert device_info.firmware_version == "1.2.3"
+    assert device_info.hardware_version == "2.0.0"
+
+
+def test_from_dict_valid():
+    data = {
+        "product_name": "Test Product",
+        "custom_name": "Test Rover",
+        "serial": "RNG-CTRL-RVR_5678",
+        "firmware_version": "1.0.0",
+        "hardware_version": "1.0.0",
+    }
+
+    device_info = DeviceInfo.from_dict(data)
+
+    assert device_info.product_name == "Test Product"
+    assert device_info.custom_name == "Test Rover"
+    assert device_info.serial == "RNG-CTRL-RVR_5678"
+    assert device_info.firmware_version == "1.0.0"
+    assert device_info.hardware_version == "1.0.0"
+
+
+def test_from_dict_partial():
+    data = {"custom_name": "Partial Rover", "firmware_version": "2.0.0"}
+
+    device_info = DeviceInfo.from_dict(data)
+
+    # Should use defaults for missing fields
+    assert device_info.product_name == PRODUCT_NAME
+    assert device_info.custom_name == "Partial Rover"
+    assert device_info.serial.startswith("RNG-CTRL-RVR_")  # Random serial
+    assert device_info.firmware_version == "2.0.0"
+    assert device_info.hardware_version == "0.0.0"
+
+
+def test_from_dict_empty():
+    device_info = DeviceInfo.from_dict({})
+
+    assert device_info.product_name == PRODUCT_NAME
+    assert device_info.custom_name == PRODUCT_NAME
+    assert device_info.serial.startswith("RNG-CTRL-RVR_")  # Random serial
+    assert device_info.firmware_version == "0.0.0"
+    assert device_info.hardware_version == "0.0.0"
+
+
+def test_from_dict_extra_fields():
+    data = {"custom_name": "Test Rover", "extra_field": "should be ignored", "another_field": 123}
+
+    device_info = DeviceInfo.from_dict(data)
+
+    assert device_info.custom_name == "Test Rover"
+    # Should not have the extra fields
+    assert not hasattr(device_info, "extra_field")
+    assert not hasattr(device_info, "another_field")
+
+
+def test_to_dict():
+    device_info = DeviceInfo(
+        custom_name="Test Rover", serial="RNG-CTRL-RVR_1234", firmware_version="1.0.0", hardware_version="1.0.0"
+    )
+
+    result = device_info.to_dict()
+
+    expected = {
+        "serial": "RNG-CTRL-RVR_1234",
+        "firmware_version": "1.0.0",
+        "hardware_version": "1.0.0",
+        "custom_name": "Test Rover",
+    }
+
+    assert result == expected
+
+
+def test_from_file_existing():
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        json.dump(
+            {
+                "custom_name": "File Rover",
+                "serial": "RNG-CTRL-RVR_9999",
+                "firmware_version": "3.0.0",
+                "hardware_version": "3.0.0",
+            },
+            f,
+        )
+        temp_file = f.name
+
+    try:
+        device_info = DeviceInfo.from_file(temp_file)
+
+        assert device_info.custom_name == "File Rover"
+        assert device_info.serial == "RNG-CTRL-RVR_9999"
+        assert device_info.firmware_version == "3.0.0"
+        assert device_info.hardware_version == "3.0.0"
+    finally:
+        os.unlink(temp_file)
+
+
+def test_from_file_nonexistent():
+    device_info = DeviceInfo.from_file("/nonexistent/file.json")
+
+    # Should return default values
+    assert device_info.product_name == PRODUCT_NAME
+    assert device_info.custom_name == PRODUCT_NAME
+    assert device_info.serial == "RNG-CTRL-RVR"
+    assert device_info.firmware_version == "0.0.0"
+    assert device_info.hardware_version == "0.0.0"
+
+
+def test_from_file_invalid_json():
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        f.write("invalid json content")
+        temp_file = f.name
+
+    try:
+        device_info = DeviceInfo.from_file(temp_file)
+
+        # Should return default values
+        assert device_info.product_name == PRODUCT_NAME
+        assert device_info.custom_name == PRODUCT_NAME
+        assert device_info.serial == "RNG-CTRL-RVR"
+        assert device_info.firmware_version == "0.0.0"
+        assert device_info.hardware_version == "0.0.0"
+    finally:
+        os.unlink(temp_file)
+
+
+def test_to_file():
+    device_info = DeviceInfo(
+        custom_name="Save Rover", serial="RNG-CTRL-RVR_8888", firmware_version="4.0.0", hardware_version="4.0.0"
+    )
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_file = os.path.join(temp_dir, "test", "device.json")
+
+        device_info.to_file(temp_file)
+
+        # Verify file was created
+        assert os.path.exists(temp_file)
+
+        # Read and verify content
+        with open(temp_file, "r") as f:
+            data = json.load(f)
+
+        expected = {
+            "serial": "RNG-CTRL-RVR_8888",
+            "firmware_version": "4.0.0",
+            "hardware_version": "4.0.0",
+            "custom_name": "Save Rover",
+        }
+
+        assert data == expected
+
+
+@patch("ve_renogy_rover.device_info.logging")
+def test_update_from_device_success(mock_logging):
+    mock_rover = Mock()
+    mock_rover.product_model.return_value = "RNG-CTRL-RVR"
+    mock_rover.serial_number.return_value = "12345"
+    mock_rover.software_version.return_value = "5.0.0"
+    mock_rover.hardware_version.return_value = "5.0.0"
+
+    device_info = DeviceInfo()
+    device_info.update_from_device(mock_rover)
+
+    assert device_info.serial == "RNG-CTRL-RVR_12345"
+    assert device_info.firmware_version == "5.0.0"
+    assert device_info.hardware_version == "5.0.0"
+
+    # Should not log any warnings
+    mock_logging.warning.assert_not_called()
+
+
+@patch("ve_renogy_rover.device_info.logging")
+def test_update_from_device_product_serial_exception(mock_logging):
+    mock_rover = Mock()
+    mock_rover.product_model.side_effect = Exception("Connection error")
+    mock_rover.serial_number.side_effect = Exception("Connection error")
+    mock_rover.software_version.return_value = "5.0.0"
+    mock_rover.hardware_version.return_value = "5.0.0"
+
+    device_info = DeviceInfo()
+    original_serial = device_info.serial
+    device_info.update_from_device(mock_rover)
+
+    # Should keep original serial
+    assert device_info.serial == original_serial
+    assert device_info.firmware_version == "5.0.0"
+    assert device_info.hardware_version == "5.0.0"
+
+    # Should log warning
+    mock_logging.warning.assert_called_once()
+
+
+@patch("ve_renogy_rover.device_info.logging")
+def test_update_from_device_firmware_exception(mock_logging):
+    mock_rover = Mock()
+    mock_rover.product_model.return_value = "RNG-CTRL-RVR"
+    mock_rover.serial_number.return_value = "12345"
+    mock_rover.software_version.side_effect = Exception("Firmware error")
+    mock_rover.hardware_version.return_value = "5.0.0"
+
+    device_info = DeviceInfo()
+    original_firmware = device_info.firmware_version
+    device_info.update_from_device(mock_rover)
+
+    assert device_info.serial == "RNG-CTRL-RVR_12345"
+    assert device_info.firmware_version == original_firmware
+    assert device_info.hardware_version == "5.0.0"
+
+    # Should log warning
+    mock_logging.warning.assert_called_once()
+
+
+@patch("ve_renogy_rover.device_info.logging")
+def test_update_from_device_hardware_exception(mock_logging):
+    mock_rover = Mock()
+    mock_rover.product_model.return_value = "RNG-CTRL-RVR"
+    mock_rover.serial_number.return_value = "12345"
+    mock_rover.software_version.return_value = "5.0.0"
+    mock_rover.hardware_version.side_effect = Exception("Hardware error")
+
+    device_info = DeviceInfo()
+    original_hardware = device_info.hardware_version
+    device_info.update_from_device(mock_rover)
+
+    assert device_info.serial == "RNG-CTRL-RVR_12345"
+    assert device_info.firmware_version == "5.0.0"
+    assert device_info.hardware_version == original_hardware
+
+    # Should log warning
+    mock_logging.warning.assert_called_once()

--- a/tests/test_rover_service.py
+++ b/tests/test_rover_service.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+
+"""
+Tests for the rover_service module.
+"""
+
+from unittest.mock import ANY, Mock, call, patch
+
+import pytest
+from pyrover.types import ChargingState
+
+from ve_renogy_rover import rover_service as rover_service_module
+from ve_renogy_rover.dbus_service import DbusService
+from ve_renogy_rover.rover_service import (
+    CUSTOM_PRODUCT_ID,
+    SETTINGS_PATH,
+    UPDATE_INTERVAL,
+    VERSION,
+    OperationMode,
+    RoverService,
+    State,
+    service_name,
+)
+
+
+@pytest.fixture(autouse=True)
+def mock_device_info_class(mock_device_info):
+    """Fixture providing a mock DeviceInfo class with from_file method."""
+    with patch("ve_renogy_rover.rover_service.DeviceInfo") as mock_class:
+        mock_class.from_file.return_value = mock_device_info
+        yield mock_class
+
+
+@pytest.fixture(autouse=True)
+def mock_rover_class(mock_rover):
+    """Fixture providing a mock Rover class."""
+    with patch("ve_renogy_rover.rover_service.Rover") as mock_class:
+        mock_class.return_value = mock_rover
+        yield mock_class
+
+
+@pytest.fixture(autouse=True)
+def mock_dbus_service(mock_dbus_context):
+    """Fixture providing a mock DBus service with context manager."""
+    service = Mock(spec=DbusService)
+    service.__enter__ = Mock(return_value=mock_dbus_context)
+    service.__exit__ = Mock(return_value=None)
+    service.add_path = Mock()
+    service.register = Mock()
+    return service
+
+
+@pytest.fixture(autouse=True)
+def mock_timeout_add():
+    """Fixture providing a mock timeout add function."""
+    return Mock(return_value=123)
+
+
+@pytest.fixture
+def rover_service(mock_device_info_class, mock_rover_class, mock_dbus_service, mock_timeout_add):
+    """Fixture providing a basic RoverService instance for testing."""
+    return RoverService(tty="/dev/ttyUSB1", dbus_service=mock_dbus_service, timeout_add_func=mock_timeout_add)
+
+
+class TestServiceName:
+
+    def test_service_name_with_full_path(self):
+        result = service_name("/dev/ttyUSB0")
+        assert result == "com.victronenergy.solarcharger.ttyUSB0"
+
+    def test_service_name_with_just_name(self):
+        result = service_name("ttyUSB1")
+        assert result == "com.victronenergy.solarcharger.ttyUSB1"
+
+    def test_service_name_with_different_device(self):
+        result = service_name("/dev/ttyACM0")
+        assert result == "com.victronenergy.solarcharger.ttyACM0"
+
+
+class TestOperationMode:
+
+    @pytest.mark.parametrize(
+        "charging_state,expected",
+        [
+            (ChargingState.DEACTIVATED, OperationMode.OFF),
+            (ChargingState.CURRENT_LIMITING, OperationMode.LIMITING),
+            (ChargingState.MPPT, OperationMode.TRACKING),
+            (None, None),
+            (ChargingState.BOOST, None),
+        ],
+    )
+    def test_from_rover(self, charging_state, expected):
+        result = OperationMode.from_rover(charging_state)
+        assert result == expected
+
+
+class TestState:
+
+    @pytest.mark.parametrize(
+        "charging_state,expected",
+        [
+            (ChargingState.DEACTIVATED, State.OFF),
+            (ChargingState.BOOST, State.BULK),
+            (ChargingState.FLOATING, State.FLOAT),
+            (ChargingState.EQUALIZING, State.EQUALIZE),
+            (None, None),
+            (ChargingState.MPPT, None),
+        ],
+    )
+    def test_from_rover(self, charging_state, expected):
+        result = State.from_rover(charging_state)
+        assert result == expected
+
+
+class TestRoverService:
+
+    def test_init(self, mock_device_info_class, mock_rover_class, mock_dbus_service, mock_timeout_add):
+        service = RoverService(tty="/dev/ttyUSB0", dbus_service=mock_dbus_service, timeout_add_func=mock_timeout_add)
+
+        # Verify the service was initialized correctly
+        assert service.tty == "/dev/ttyUSB0"
+        assert service._dbus_service == mock_dbus_service
+        assert service._timeout_add == mock_timeout_add
+
+        # Verify the device info was loaded
+        mock_device_info_class.from_file.assert_called_once()
+
+        # Verify the timeout was added
+        mock_timeout_add.assert_called_once_with(UPDATE_INTERVAL, service._update_path_values)
+
+        # Verify the service was registered
+        mock_dbus_service.register.assert_called_once()
+
+    def test_tty_property(self, rover_service):
+        assert rover_service.tty == "/dev/ttyUSB1"
+
+    @pytest.mark.parametrize(
+        "tty,expected",
+        [
+            ("/dev/ttyUSB0", 0),
+            ("/dev/ttyUSB1", 1),
+            ("/dev/ttyUSB10", 10),
+            ("ttyUSB0", 0),
+            ("ttyUSB1", 1),
+        ],
+    )
+    def test_usb_number_property_valid(self, tty, expected, mock_dbus_service, mock_timeout_add):
+        service = RoverService(tty, mock_dbus_service, mock_timeout_add)
+        assert service.usb_number == expected
+
+    @pytest.mark.parametrize(
+        "tty",
+        [
+            "/dev/ttyACM0",
+            "/dev/ttyS0",
+            "invalid",
+            "/dev/ttyUSB",
+            "/dev/ttyUSBa",
+        ],
+    )
+    def test_usb_number_property_invalid(self, tty, mock_dbus_service, mock_timeout_add):
+        with pytest.raises(ValueError, match=f"Unsupported TTY name: {tty}"):
+            RoverService(tty, mock_dbus_service, mock_timeout_add)
+
+    def test_service_name_property(self, rover_service):
+        expected = "com.victronenergy.solarcharger.ttyUSB1"
+        assert rover_service.service_name == expected
+
+    def test_connection_property(self, rover_service):
+        expected = "Renogy Rover MPPT on USB1"
+        assert rover_service.connection == expected
+
+    def test_device_instance_property(self, rover_service):
+        assert rover_service.device_instance == 289  # 2881
+
+    def test_device_instance_property_caching(self, rover_service):
+        # First call should set the instance
+        instance1 = rover_service.device_instance
+        assert instance1 == 289
+
+        # Change the tty and verify that the instance is not updated (cached)
+        rover_service._tty = "/dev/ttyUSB0"
+        instance2 = rover_service.device_instance
+        assert instance2 == instance1
+
+    def test_rover_property(self, mock_rover_class, rover_service):
+        rover = rover_service.rover
+
+        assert rover == mock_rover_class.return_value
+        mock_rover_class.assert_called_once_with(address=1, port="/dev/ttyUSB1")
+
+    def test_rover_property_caching(self, mock_rover_class, rover_service):
+        r1 = rover_service.rover
+        r2 = rover_service.rover
+
+        assert id(r1) == id(r2)
+        mock_rover_class.assert_called_once()
+
+    def test_register_dbus_service(self, mock_device_info_class, rover_service):
+        # Check that all expected add_path calls were made
+        add_path_calls = {
+            call_arg[0][0]: call_arg[0][1] for call_arg in rover_service._dbus_service.add_path.call_args_list
+        }
+        assert add_path_calls == {
+            "/Mgmt/ProcessName": rover_service_module.__file__,
+            "/Mgmt/ProcessVersion": VERSION,
+            "/Mgmt/Connection": "Renogy Rover MPPT on USB1",
+            "/DeviceInstance": 289,
+            "/ProductId": CUSTOM_PRODUCT_ID,
+            "/ProductName": mock_device_info_class.from_file.return_value.product_name,
+            "/CustomName": mock_device_info_class.from_file.return_value.custom_name,
+            "/Serial": mock_device_info_class.from_file.return_value.serial,
+            "/FirmwareVersion": mock_device_info_class.from_file.return_value.firmware_version,
+            "/HardwareVersion": mock_device_info_class.from_file.return_value.hardware_version,
+            "/Connected": 1,
+            "/NrOfTrackers": 1,
+            "/Mode": 1,
+            "/ErrorCode": 0,
+            "/DeviceOffReason": 0,
+            "/Pv/V": 0,
+            "/Pv/I": 0,
+            "/Yield/Power": 0,
+            "/Dc/0/Voltage": 0,
+            "/Dc/0/Current": 0,
+            "/Link/TemperatureSense": 0,
+            "/Link/TemperatureSenseActive": True,
+            "/History/Daily/0/Yield": 0,
+            "/History/Daily/0/MaxPower": 0,
+            "/MppOperationMode": 0,
+            "/State": 0,
+        }
+
+        # Verify the timeout was added
+        rover_service._timeout_add.assert_called_once_with(UPDATE_INTERVAL, rover_service._update_path_values)
+
+        # Verify the service was registered
+        rover_service._dbus_service.register.assert_called_once()
+
+    def test_update_path_values_success(self, rover_service, mock_rover):
+        rover_service._rover = mock_rover
+
+        # Call the update method
+        result = rover_service._update_path_values()
+
+        assert result is True
+
+        # Verify that the context manager was used
+        rover_service._dbus_service.__enter__.assert_called_once()
+        rover_service._dbus_service.__exit__.assert_called_once()
+
+        # Verify that values were set in the context
+        context = rover_service._dbus_service.__enter__.return_value
+        update_calls = {call[0][0]: call[0][1] for call in context.__setitem__.call_args_list}
+        assert update_calls == {
+            "/Pv/V": 24.5,
+            "/Pv/I": 2.1,
+            "/Yield/Power": 24.5 * 2.1,  # solar_voltage * charging_current
+            "/Dc/0/Voltage": 12.8,
+            "/Dc/0/Current": 50.0 / 12.8,  # charging_power / battery_voltage
+            "/Link/TemperatureSense": 25.0,
+            "/History/Daily/0/Yield": 1.2,
+            "/History/Daily/0/MaxPower": 50.0,  # max_charging_power_today / 1000
+            "/MppOperationMode": OperationMode.TRACKING.value,
+            # Note: /State is not updated because ChargingState.MPPT doesn't map to any State enum value
+        }
+
+    def test_update_path_values_with_exceptions(self, rover_service, mock_rover):
+        # Update only the properties that need to change for this test
+        mock_rover.solar_voltage.side_effect = Exception("Connection error")
+        mock_rover.charging_current.side_effect = Exception("Connection error")
+        mock_rover.charging_power.side_effect = Exception("Connection error")
+        mock_rover.battery_voltage.side_effect = Exception("Connection error")
+        mock_rover.battery_temperature.side_effect = Exception("Sensor error")
+        mock_rover.charging_state.side_effect = Exception("Connection error")
+        mock_rover.max_charging_power_today.side_effect = Exception("Connection error")
+        mock_rover.power_generation_today.side_effect = Exception("Connection error")
+        mock_rover.max_charging_power_today.side_effect = Exception("Connection error")
+
+        rover_service._rover = mock_rover
+
+        # Call the update method
+        result = rover_service._update_path_values()
+
+        assert result is True
+
+        # There should be no updates when there are exceptions
+        context = rover_service._dbus_service.__enter__.return_value
+        update_calls = {call[0][0]: call[0][1] for call in context.__setitem__.call_args_list}
+        assert update_calls == {}
+
+    def test_on_custom_name_change(self, rover_service):
+        # Test changing the custom name
+        new_name = "New Custom Name"
+        result = rover_service._on_custom_name_change("/CustomName", new_name)
+
+        assert result is True
+        assert rover_service.device_info.custom_name == new_name
+        rover_service.device_info.to_file.assert_called_once_with(SETTINGS_PATH)


### PR DESCRIPTION
- Gracefully handles exceptions from the rover controller to avoid killing the polling loop
- Improve dbus and rover mapping of values (e.g. Charging current
- Pushes out the dbus service since we can't easily reference it from a non-Venus OS (e.g. for testing without having real a device handy)
- Improves testability