### PR TITLE
Fix charging power metric (again)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ The driver exposes data under `com.victronenergy.solarcharger.ttyUSBx`:
 - `/Pv/V` - Solar panel voltage (V)
 - `/Pv/I` - Solar panel current (A)
 - `/Yield/Power` - Total power output (W)
+- `/Yield/User` - Total energy produced (kWh), user-resettable
+- `/Yield/System` - Total energy produced (kWh), non-resettable
 - `/Dc/0/Voltage` - Battery voltage (V)
 - `/Dc/0/Current` - Battery charging current (A)
 - `/History/Daily/0/Yield` - Today's energy yield (kWh)

--- a/src/ve_renogy_rover/rover_service.py
+++ b/src/ve_renogy_rover/rover_service.py
@@ -193,6 +193,8 @@ class RoverService(object):
             "/Pv/V": 0,  # Voltage in Volts, exists only for single tracker devices
             "/Pv/I": 0,  # Current in Amps, exists only for single tracker devices
             "/Yield/Power": 0,  # Power in Watts, total yield power
+            "/Yield/User": 0,  # Total energy produced (kWh), user-resettable
+            "/Yield/System": 0,  # Total energy produced (kWh), non-resettable
             "/Dc/0/Voltage": 0,  # Actual battery voltage
             "/Dc/0/Current": 0,  # Actual battery charging current
             "/Link/TemperatureSense": 0,
@@ -221,27 +223,15 @@ class RoverService(object):
                 logging.error(f"Error getting `{func.__name__}` value from rover: {e}")
                 return None
 
-        def solar_power():
-            v = try_(rover.solar_voltage)
-            i = try_(rover.solar_current)
-            if v is None or i is None:
-                return None
-            return v * i
-
-        def charging_voltage():
-            p = try_(rover.charging_power)
-            i = try_(rover.charging_current)
-            if p and i and i > 0:
-                return p / i
-            return None
-
         try:
             updates = {
                 path: value
                 for path, value in {
                     "/Pv/V": try_(rover.solar_voltage),
                     "/Pv/I": try_(rover.solar_current),
-                    "/Yield/Power": solar_power(),
+                    "/Yield/Power": try_(rover.charging_power),
+                    "/Yield/User": try_(rover.cumulative_power_generation),
+                    "/Yield/System": try_(rover.cumulative_power_generation),
                     "/Dc/0/Voltage": try_(rover.battery_voltage),
                     "/Dc/0/Current": try_(rover.charging_current),
                     "/Link/TemperatureSense": try_(rover.battery_temperature),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,6 +52,7 @@ def mock_rover():
     rover.serial_number.return_value = "12345"
     rover.software_version.return_value = "1.0.0"
     rover.hardware_version.return_value = "1.0.0"
+    rover.cumulative_power_generation.return_value = 1.1 # kWh
 
     return rover
 

--- a/tests/test_rover_service.py
+++ b/tests/test_rover_service.py
@@ -223,6 +223,8 @@ class TestRoverService:
             "/Pv/V": 0,
             "/Pv/I": 0,
             "/Yield/Power": 0,
+            "/Yield/User": 0,
+            "/Yield/System": 0,
             "/Dc/0/Voltage": 0,
             "/Dc/0/Current": 0,
             "/Link/TemperatureSense": 0,
@@ -259,14 +261,16 @@ class TestRoverService:
         assert update_calls == {
             "/Pv/V": 24.5,
             "/Pv/I": 2.1,
-            "/Yield/Power": 24.5 * 2.1,  # solar_voltage * charging_current
+            "/Yield/Power": 50.0,
+            "/Yield/User": 1.1,
+            "/Yield/System": 1.1,
             "/Dc/0/Voltage": 12.8,
             "/Dc/0/Current": 2.1,
             "/Link/TemperatureSense": 25.0,
             "/History/Daily/0/Yield": 1.2,
-            "/History/Daily/0/MaxPower": 500.0,
+            "/History/Daily/0/MaxPower": 500,
             "/History/Daily/0/Pv/0/Yield": 1.2,
-            "/History/Daily/0/Pv/0/MaxPower": 500.0,
+            "/History/Daily/0/Pv/0/MaxPower": 500,
             "/MppOperationMode": OperationMode.TRACKING.value,
             "/State": State.BULK.value,
         }


### PR DESCRIPTION
This corrects some incorrect metrics related to PV yield. It also finally properly populates the solar yield chart on the main VRM dashboard..

<img width="1434" height="768" alt="image" src="https://github.com/user-attachments/assets/45da38a0-001c-4fa9-a376-4950658b621a" />
