### PR TITLE
Fix run script calling nonexistent module

### DIFF
--- a/run
+++ b/run
@@ -3,4 +3,4 @@
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 LOG_FILE="$SCRIPT_DIR/driver.log"
 
-python3 -m ve_renogy_rover.main "$@" 2>> "$LOG_FILE"
+python3 -m ve_renogy_rover.rover_service "$@" 2>> "$LOG_FILE"


### PR DESCRIPTION
## Summary
- `run` was invoking `ve_renogy_rover.main` which does not exist — the correct entry point is `ve_renogy_rover.rover_service`
- This caused the serial-starter-managed service to crash immediately on launch
- With the service down, Venus OS's `gps-dbus` claimed `/dev/ttyUSB0` instead, blocking the rover driver entirely

## Test Plan
- [ ] Deploy to Pi (`pip3 install .`)
- [ ] Stop the GPS service: `svc -d /service/gps-dbus.ttyUSB0`
- [ ] Trigger re-detection: `udevadm trigger --action=add /dev/ttyUSB0`
- [ ] Confirm `/data/ve-renogy-rover/driver.log` shows the service starting cleanly
- [ ] Confirm solar charger appears in Venus OS UI